### PR TITLE
[REFACTOR] 프로젝트 페이지 조회/수정 이후 동기화 리팩토링

### DIFF
--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -16,16 +16,17 @@ const Input = ({
   onButtonClick,
   onChange,
 }: InputProps) => {
-  const [internalValue, setInternalValue] = useState(value);
+  const [internalValue, setInternalValue] = useState("");
   const [inputStatus, setInputStatus] = useState<
     "normal" | "success" | "error"
   >(status);
   const [innerMessage, setInnerMessage] = useState("");
 
   useEffect(() => {
+    setInternalValue(value);
     setInputStatus(status);
     if (message) setInnerMessage(message);
-  }, [status, message]);
+  }, [status, message, value]);
 
   useEffect(() => {
     if (internalValue === "") {

--- a/src/components/layout/projectLayout/Header/index.tsx
+++ b/src/components/layout/projectLayout/Header/index.tsx
@@ -10,17 +10,19 @@ import ProjectEditModal from "../ProjectEditModal";
 
 const ProjectHeader = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { name, image } = useSelector((state: RootState) => state.project);
+  const { projectName, projectImage } = useSelector(
+    (state: RootState) => state.project
+  );
 
   const handleClose = () => setIsModalOpen(false);
   const handleOpen = () => setIsModalOpen(true);
 
   return (
     <Container>
-      <img src={image} alt="project image" />
+      <img src={projectImage} alt="project image" />
       <TabSection>
         <InfoSection>
-          <h1>{name}</h1>
+          <h1>{projectName}</h1>
           <LabelSection>
             <Label>진행중</Label>
             <Label colors="secondary">

--- a/src/components/layout/projectLayout/ProjectEditModal/index.tsx
+++ b/src/components/layout/projectLayout/ProjectEditModal/index.tsx
@@ -2,7 +2,7 @@ import Modal from "@/components/common/Modal";
 import { AiFillFolder, AiOutlineUpload } from "react-icons/ai";
 import { ProjectEditModalProps } from "./type";
 import { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store/store";
 import {
   DeleteSection,
@@ -19,6 +19,7 @@ import { BiCheckbox, BiSolidCheckboxChecked } from "react-icons/bi";
 import { useUpdateProject } from "@/query/project/useUpdateProject";
 import { useParams } from "react-router-dom";
 import { useDeleteProject } from "@/query/project/useDeleteProject";
+import { setProject } from "@/store/project";
 
 const ProjectEditModal = ({ isOpen, onClose }: ProjectEditModalProps) => {
   const { projectId } = useParams();
@@ -29,10 +30,20 @@ const ProjectEditModal = ({ isOpen, onClose }: ProjectEditModalProps) => {
   const [isContactVisible, setIsContactVisible] = useState(false);
   const [status, setStatus] = useState<"active" | "completed">("active");
 
+  const dispatch = useDispatch();
   const projectState = useSelector((state: RootState) => state.project);
 
   const { mutate } = useUpdateProject({
     onSuccess: () => {
+      dispatch(
+        setProject({
+          ...projectState,
+          projectName: title,
+          projectImage: previewUrl,
+          status: status === "active",
+          revealedNumber: isContactVisible,
+        })
+      );
       onClose();
     },
     onError: (err) => {

--- a/src/components/layout/projectLayout/ProjectEditModal/index.tsx
+++ b/src/components/layout/projectLayout/ProjectEditModal/index.tsx
@@ -47,11 +47,11 @@ const ProjectEditModal = ({ isOpen, onClose }: ProjectEditModalProps) => {
 
   useEffect(() => {
     if (isOpen && projectState.id !== null) {
-      setTitle(projectState.name);
+      setTitle(projectState.projectName);
       setImage(null);
-      setPreviewUrl(projectState.image);
-      setIsContactVisible(projectState.isContactVisible);
-      setStatus(projectState.status);
+      setPreviewUrl(projectState.projectImage);
+      setIsContactVisible(projectState.revealedNumber);
+      setStatus(projectState.status ? "active" : "completed");
     }
   }, [isOpen, projectState]);
 
@@ -68,7 +68,7 @@ const ProjectEditModal = ({ isOpen, onClose }: ProjectEditModalProps) => {
     const formData = new FormData();
     formData.append("projectName", title);
     formData.append("status", String(status === "active"));
-    formData.append("isRevealedNumber", String(isContactVisible));
+    formData.append("revealedNumber", String(isContactVisible));
     if (image) {
       formData.append("projectImage", image);
     }

--- a/src/pages/Projects/index.tsx
+++ b/src/pages/Projects/index.tsx
@@ -5,9 +5,12 @@ import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useProjectList } from "@/query/project/useProjectList";
 import ProjectCreateModal from "@/components/projects/ProjectCreateModal";
+import { useDispatch } from "react-redux";
+import { setProject } from "@/store/project";
 
 const Projects = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { data: projects, isLoading, isError } = useProjectList();
@@ -37,6 +40,13 @@ const Projects = () => {
               project_created_time={project.projectCreatedTime}
               status={project.status}
               onClick={() => {
+                dispatch(
+                  setProject({
+                    id: project.projectId,
+                    projectName: project.projectName,
+                    projectImage: project.projectImage,
+                  })
+                );
                 navigate(`/project/${project.projectId}/home`);
               }}
             />

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -3,10 +3,10 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 const initialState: ProjectStoreInfo = {
   id: null,
-  name: "",
-  image: "",
+  projectName: "",
+  projectImage: "",
   description: "",
-  isContactVisible: false,
+  revealedNumber: false,
   isLeader: false,
   status: false,
 };

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -15,8 +15,8 @@ const projectSlice = createSlice({
   name: "selectedProject",
   initialState,
   reducers: {
-    setProject(state, action: PayloadAction<ProjectStoreInfo>) {
-      return action.payload;
+    setProject(state, action: PayloadAction<Partial<ProjectStoreInfo>>) {
+      return { ...state, ...action.payload };
     },
     resetProject() {
       return initialState;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -11,10 +11,10 @@ export interface ProjectType {
 
 // 프로젝트 상세 조회 (응답)
 export interface ProjectInfo {
-  name: string;
-  image: string;
+  projectName: string;
+  projectImage: string;
   description: string;
-  isContactVisible: boolean;
+  revealedNumber: boolean;
   isLeader: boolean;
   status: boolean;
 }


### PR DESCRIPTION
## 📝 PR 설명

- 수정 이후 상세 페이지 변경 로직 추가
- 프로젝트 페이지 진입 시 store에 미리 보이는 이미지들을 먼저 넘겨주어 끊겨보이지 않도록 리팩토링
- 페이지 진입 시 상세 정보 불러오는 api 이용하여 store에서 전역으로 관리하도록 리팩토링

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #79 
