### PR TITLE
[FEAT] 게시글 내 태그 색상 통합

### DIFF
--- a/src/components/project/board/BoardList/style.ts
+++ b/src/components/project/board/BoardList/style.ts
@@ -1,12 +1,6 @@
 import styled from "@emotion/styled";
 import { BoardLabelProps } from "./type";
-
-const tagColorMap: Record<string, string> = {
-  회의록: "#CC9500",
-  파일: "#015C99",
-  기타: "#995501",
-  공지: "#019963",
-};
+import { tagColorMap } from "@/utils/postTagColor";
 
 export const ListContainer = styled.div``;
 
@@ -53,7 +47,7 @@ export const BoardLabel = styled.div<BoardLabelProps>`
   align-items: center;
 
   border-radius: 20px;
-  background-color: ${({ tag }) => tagColorMap[tag]};
+  background-color: ${({ tag, theme }) => theme.colors[tagColorMap[tag]]};
 
   > p {
     font-size: ${({ theme }) => theme.fontSize.caption};

--- a/src/pages/project/Board/Post/index.tsx
+++ b/src/pages/project/Board/Post/index.tsx
@@ -25,6 +25,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useGetPost } from "@/query/board/useGetPost";
 import { formatTodoDate } from "@/utils/formatTime";
 import { useDeletePost } from "@/query/board/useDeletePost";
+import { tagColorMap } from "@/utils/postTagColor";
 
 const Post = () => {
   const { postId } = useParams();
@@ -90,7 +91,9 @@ const Post = () => {
           </InfoTitle>
 
           <LabelWrapper>
-            <Label textColors="textWhite">{data.tag}</Label>
+            <Label colors={tagColorMap[data.tag]} textColors="textWhite">
+              {data.tag}
+            </Label>
           </LabelWrapper>
         </InfoWrapper>
 

--- a/src/pages/project/Board/PostWrite/index.tsx
+++ b/src/pages/project/Board/PostWrite/index.tsx
@@ -28,6 +28,7 @@ import { LabelWrapper } from "../../Task/style";
 import { useCreatePost } from "@/query/board/useCreatePost";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useUpdatePost } from "@/query/board/useUpdatePost";
+import { tagColorMap } from "@/utils/postTagColor";
 
 const PostWrite = () => {
   const { projectId, postId } = useParams();
@@ -124,7 +125,7 @@ const PostWrite = () => {
           </InfoTitle>
 
           <LabelWrapper ref={labelRef} onClick={handleOpenModal}>
-            <Label textColors="textWhite" colors={tag.color}>
+            <Label textColors="textWhite" colors={tagColorMap[tag.label]}>
               {tag.label}
             </Label>
           </LabelWrapper>

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -22,6 +22,7 @@ declare module "@emotion/react" {
       brown: string;
       gray: string;
       default: string;
+      [key: string]: string;
     };
     fontSize: Record<string, string>;
     fontWeight: Record<string, number>;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -71,7 +71,7 @@ export const darkTheme = {
     danger: "#EF4444",
     red: "#783A39",
     orange: "#7D4D24",
-    yellow: "#8F6B3",
+    yellow: "#8F6B34",
     green: "#2F654A",
     blue: "#2C5167",
     purple: "#51376B",

--- a/src/utils/postTagColor.ts
+++ b/src/utils/postTagColor.ts
@@ -1,0 +1,14 @@
+export const tagList = [
+  { label: "공지", color: "green" },
+  { label: "회의록", color: "yellow" },
+  { label: "파일", color: "blue" },
+  { label: "기타", color: "brown" },
+] as const;
+
+export const tagColorMap: Record<string, string> = tagList.reduce(
+  (acc, tag) => {
+    acc[tag.label] = tag.color;
+    return acc;
+  },
+  {} as Record<string, string>
+);


### PR DESCRIPTION
## 📝 PR 설명

- 각각 관리하던 게시글에 고정된 태그명과 색상을 전역 변수로 관리
- 게시글 목록, 조회, 작성, 수정 페이지에서 해당 태그와 색상을 매칭
- theme.colors 에 string으로 접근이 가능하도록 type 수정
- theme 중 다크 테마의 노란 색상 오타 수정

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #122 
