### PR TITLE
[FEAT] appLayout 헤더에 로그인 한 유저 정보 반영

### DIFF
--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -44,7 +44,8 @@ export const reissueToken = async (userId: number) => {
 
 // 회원 정보 요청
 export const getUserProfile = async () => {
-  return instance.post("/user/profile");
+  const res = await instance.post("/user/profile");
+  return res.data.data
 };
 
 // 회원 정보 수정

--- a/src/components/layout/appLayout/Header/index.tsx
+++ b/src/components/layout/appLayout/Header/index.tsx
@@ -2,8 +2,12 @@ import Button from "@/components/common/Button";
 import { AiOutlineBell } from "react-icons/ai";
 import { Container, Content, Logo, UserInfo, UserSection } from "./style";
 import logo from "@/assets/logo/logo.png";
+import { useUserProfile } from "@/query/auth/useUserProfile";
+import { IoMdSettings } from "react-icons/io";
 
 const Header = () => {
+  const { data } = useUserProfile();
+
   return (
     <Container>
       <Content>
@@ -14,17 +18,17 @@ const Header = () => {
 
         <UserSection>
           <UserInfo>
-            <Button>yundoll</Button>
-            <Button variant="secondary">mar0722@naver.com</Button>
+            <Button variant="primary">{data.name}</Button>
+            <Button variant="secondary">{data.email}</Button>
+            <Button variant="secondary" iconOnly>
+              <IoMdSettings />
+            </Button>
             <Button variant="secondary" iconOnly>
               <AiOutlineBell />
             </Button>
           </UserInfo>
 
-          <img
-            src="https://we-up-public.s3.ap-northeast-2.amazonaws.com/smiley3.png"
-            alt="profile-iamge"
-          />
+          <img src={data.profileImage} alt="profile-iamge" />
         </UserSection>
       </Content>
     </Container>

--- a/src/components/layout/appLayout/Header/style.ts
+++ b/src/components/layout/appLayout/Header/style.ts
@@ -47,4 +47,13 @@ export const UserInfo = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
+
+  > button {
+    cursor: auto;
+  }
+
+  > button:nth-child(3),
+  > button:nth-child(4) {
+    cursor: pointer;
+  }
 `;


### PR DESCRIPTION
## 📝 PR 설명

- 회원 정보 불러오기 API Query 리펙토링
- 상단 바에 로그인한 사용자 정보 반영
- 상단 바 스타일링 수정

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #127 
