### PR TITLE
[FIX] 달력 표기되는 일정의 종료 기간을 하루 늦춰 적용

### DIFF
--- a/src/pages/project/Home/index.tsx
+++ b/src/pages/project/Home/index.tsx
@@ -9,6 +9,7 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import { CalendarWrapper, Container } from "./style";
 import { useGetTodoList } from "@/query/todo/useGetTodoList";
 import { useTheme } from "@emotion/react";
+import { formatTodoDate } from "@/utils/formatTime";
 
 const Home = () => {
   const theme = useTheme();
@@ -18,6 +19,8 @@ const Home = () => {
 
   const { data } = useProjectInfo(parsedProjectId);
   const { data: getTodoList } = useGetTodoList(parsedProjectId);
+
+  console.log(getTodoList);
 
   useEffect(() => {
     if (data) {
@@ -31,6 +34,14 @@ const Home = () => {
       console.log(data);
     }
   }, [data, dispatch, parsedProjectId]);
+
+  // 달력에 종료 날짜까지 표시하기 위해 종료 날짜를 하루 미루는 로직 추가
+  const addOneDay = (date: Date): Date => {
+    const newDate = new Date(date);
+    newDate.setDate(newDate.getDate() + 1);
+    return newDate;
+  };
+
   return (
     <Container>
       <Description />
@@ -42,7 +53,9 @@ const Home = () => {
             getTodoList?.map((todo) => ({
               title: todo.todoName,
               start: todo.startDate,
-              end: todo.endDate ?? undefined,
+              end: todo.endDate
+                ? formatTodoDate(addOneDay(new Date(todo.endDate)))
+                : undefined,
               textColor: todo.isMyTodo
                 ? theme.colors.textWhite
                 : theme.colors.textLight,


### PR DESCRIPTION
## 📝 PR 설명

FullCalendar에서는 end 날짜가 exclusive로 처리되어 기존 기획과 달리 설정한 종료 날짜보다 하루 앞당겨 출력됨.
종료 날짜를 하루 미뤄 설정하여 기존 기획대로 출력되도록 설정.

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #138
