### PR TITLE
[FIX] 탭 이동 시 채팅 중복 출력되는 오류

### DIFF
--- a/src/components/project/chat/ChatMessages/index.tsx
+++ b/src/components/project/chat/ChatMessages/index.tsx
@@ -27,6 +27,11 @@ const ChatMessages = ({ roomId, client }: ChatMessagesProps) => {
     ...newMessages,
   ];
 
+  // 서버에서 새 데이터 오면 초기화 (중복 방지)
+  useEffect(() => {
+    setNewMessages([]);
+  }, [data]);
+
   // 구독, 메세지 창 변경되면 웹소켓 유지한 채로 구독 정보 변경
   useEffect(() => {
     if (!client || !client.connected) return;

--- a/src/query/auth/useEditUserProfile.ts
+++ b/src/query/auth/useEditUserProfile.ts
@@ -1,5 +1,5 @@
 import { editUserProfile } from "@/apis/auth/auth";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
 export const useEditUserProfile = ({
@@ -9,9 +9,13 @@ export const useEditUserProfile = ({
   onSuccess?: () => void;
   onError?: (error: AxiosError<{ message: string }>) => void;
 }) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ data }: { data: FormData }) => editUserProfile(data),
-    onSuccess,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+      onSuccess?.();
+    },
     onError,
   });
 };

--- a/src/query/auth/useUserProfile.ts
+++ b/src/query/auth/useUserProfile.ts
@@ -5,5 +5,6 @@ export const useUserProfile = () => {
   return useQuery({
     queryKey: ["userProfile"],
     queryFn: getUserProfile,
+    staleTime: Infinity,
   });
 };

--- a/src/query/chat/useGetChat.ts
+++ b/src/query/chat/useGetChat.ts
@@ -8,6 +8,7 @@ export const useGetChat = (roomId: number, size: number = 20) => {
     initialPageParam: 0,
     queryFn: ({ pageParam = 0 }) =>
       getChatHistory(roomId, pageParam as number, size),
+    refetchOnWindowFocus: false,
     getNextPageParam: (data) => {
       if (data.lastPage) return undefined;
       return data.page + 1;


### PR DESCRIPTION
## 📝 PR 설명

### 렌더링 오류 해결 : React Query 설정 변경
- 사용자 정보 쿼리: staleTime을 Infinity로 설정하여 직접 수정 전까지 fresh 상태 유지
- 사용자 정보 수정 쿼리 : 성공 시 정보 조회 쿼리 refetch 처리
- 채팅 내역 쿼리 : 웹 소켓이 연결되어 있으므로 refetchOnWindowFocus를 false로 설정하여 불필요한 렌더링 방지

### 채팅 중복 방지
- 채팅 내역 fetch 시, 웹소켓으로 수신된 newMessages 상태 초기화
- 서버에서 가져온 데이터와 중복되어 UI 출력되는 문제 해결

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #159 
