### PR TITLE
fix: 채팅 페이지 테스트 및 오류 수

### DIFF
--- a/src/apis/chat/chat.ts
+++ b/src/apis/chat/chat.ts
@@ -62,13 +62,15 @@ export const getChatHistory = async (
   size: number
 ): Promise<ChatApiResponse> => {
   const res = await instance.post(`/chat/messages/${roomId}`, { page, size });
-  console.log(res.data.data);
   return res.data.data;
 };
 
 // 채팅 이미지 전송
-export const sendImageMessage = async (data: FormData): Promise<void> =>
-  await instance.post(`/send/image`, data, {
+export const sendImageMessage = async (
+  data: FormData,
+  roomId: number
+): Promise<void> =>
+  await instance.post(`/chat/send/image/${roomId}`, data, {
     headers: { "Content-Type": "multipart/form-data" },
   });
 

--- a/src/components/project/chat/ChatCreateModal/index.tsx
+++ b/src/components/project/chat/ChatCreateModal/index.tsx
@@ -9,6 +9,8 @@ import {
 } from "react-icons/bi";
 import { MemberItem, MemberItemWrapper, MemberSection } from "./style";
 import { useCreateChat } from "@/query/chat/useCreatChatRoom";
+import { useSelector } from "react-redux";
+import { RootState } from "@/store/store";
 
 interface Props {
   projectId: number;
@@ -24,6 +26,8 @@ const ChatCreateModal = ({ onClose, projectId }: Props) => {
   const { data: invitableMembers } = useGetMembers(projectId);
   // 채팅방 생성
   const { mutate: createChatRoom } = useCreateChat();
+  // memberId 꺼내오기
+  const isMyId = useSelector((state: RootState) => state.project.memberId);
 
   const handleCreateChat = () => {
     if (!chatTitle.trim()) {
@@ -58,29 +62,31 @@ const ChatCreateModal = ({ onClose, projectId }: Props) => {
       <MemberSection>
         <p>팀원 선택</p>
         <MemberItemWrapper>
-          {invitableMembers?.map((member) => {
-            const isSelected = selectedUserIds.includes(member.memberId);
+          {invitableMembers
+            ?.filter((member) => member.memberId !== isMyId)
+            .map((member) => {
+              const isSelected = selectedUserIds.includes(member.memberId);
 
-            return (
-              <MemberItem
-                key={member.memberId}
-                isSelected={isSelected}
-                onClick={() => {
-                  setSelectedUserIds((prev) =>
-                    isSelected
-                      ? prev.filter((id) => id !== member.memberId)
-                      : [...prev, member.memberId]
-                  );
-                }}
-                className={isSelected ? "selected" : ""}
-              >
-                <img src={member.profileImage} alt="member_profile" />
-                <p>{member.name}</p>
+              return (
+                <MemberItem
+                  key={member.memberId}
+                  isSelected={isSelected}
+                  onClick={() => {
+                    setSelectedUserIds((prev) =>
+                      isSelected
+                        ? prev.filter((id) => id !== member.memberId)
+                        : [...prev, member.memberId]
+                    );
+                  }}
+                  className={isSelected ? "selected" : ""}
+                >
+                  <img src={member.profileImage} alt="member_profile" />
+                  <p>{member.name}</p>
 
-                {isSelected ? <BiSolidCheckboxChecked /> : <BiCheckbox />}
-              </MemberItem>
-            );
-          })}
+                  {isSelected ? <BiSolidCheckboxChecked /> : <BiCheckbox />}
+                </MemberItem>
+              );
+            })}
         </MemberItemWrapper>
       </MemberSection>
     </Modal>

--- a/src/components/project/chat/ChatInput/index.tsx
+++ b/src/components/project/chat/ChatInput/index.tsx
@@ -85,16 +85,14 @@ const ChatInput = ({ roomId, client }: ChatInputProps) => {
     if (!imageFile || !roomId) return;
 
     const formData = new FormData();
-    formData.append("projectId", String(roomId));
-    formData.append("roomId", String(roomId));
-    formData.append("userId", String(senderId));
+    formData.append("senderId", String(senderId));
     formData.append("file", imageFile);
 
     formData.forEach((value, key) => {
       console.log(`${key}:`, value);
     });
 
-    sendImage(formData);
+    sendImage({ data: formData, roomId });
     setIsModalOpen(false);
   };
 

--- a/src/components/project/chat/ChatMessageCard/index.tsx
+++ b/src/components/project/chat/ChatMessageCard/index.tsx
@@ -33,7 +33,7 @@ const ChatMessageCard = React.memo(
     originalMessage,
     originalSenderName,
   }: ChatCardProps) => {
-    const userId = useSelector((state: RootState) => state.auth.userId);
+    const userId = useSelector((state: RootState) => state.project.memberId);
     const isRight = senderId === userId;
 
     if (senderType === "SYSTEM") {

--- a/src/components/project/chat/ChatMessageCard/index.tsx
+++ b/src/components/project/chat/ChatMessageCard/index.tsx
@@ -1,11 +1,14 @@
 import { ChatCardProps } from "@/types/chat";
 import {
+  AiTextCard,
   ContainerCard,
   ImageCard,
   ImgWrapper,
   MessageTime,
   MyCardContainer,
   MyTextCard,
+  ReplyMessage,
+  ReplyName,
   SystemCard,
   SystemCardContainer,
   TextCard,
@@ -27,6 +30,8 @@ const ChatMessageCard = React.memo(
     isShowTime,
     isShowUserInfo,
     senderType,
+    originalMessage,
+    originalSenderName,
   }: ChatCardProps) => {
     const userId = useSelector((state: RootState) => state.auth.userId);
     const isRight = senderId === userId;
@@ -56,6 +61,34 @@ const ChatMessageCard = React.memo(
       );
     }
 
+    if (senderType === "AI") {
+      return (
+        <ContainerCard>
+          <ImgWrapper>
+            {isShowUserInfo && (
+              <img src={senderProfileImage} alt="ai profile" />
+            )}
+          </ImgWrapper>
+          <TextCardWrapper>
+            {isShowUserInfo && <p>{senderName}</p>}
+            {isImage ? (
+              <ImageCard src={message} />
+            ) : (
+              <AiTextCard>
+                <div>
+                  <ReplyName>{originalSenderName}</ReplyName>
+                  <ReplyMessage>{originalMessage}</ReplyMessage>
+                </div>
+                <hr />
+                <p>{message}</p>
+              </AiTextCard>
+            )}
+          </TextCardWrapper>
+          {isShowTime && <MessageTime>{formatChatTime(sentAt)}</MessageTime>}
+        </ContainerCard>
+      );
+    }
+
     return (
       <ContainerCard>
         <ImgWrapper>
@@ -68,7 +101,7 @@ const ChatMessageCard = React.memo(
           {isImage ? (
             <ImageCard src={message} />
           ) : (
-            <TextCard isAi={senderType === "AI"}>
+            <TextCard>
               <p>{message}</p>
             </TextCard>
           )}

--- a/src/components/project/chat/ChatMessageCard/style.ts
+++ b/src/components/project/chat/ChatMessageCard/style.ts
@@ -87,16 +87,14 @@ export const TextCardWrapper = styled.div`
   }
 `;
 
-export const TextCard = styled.div<{ isAi: boolean }>`
+export const TextCard = styled.div`
   width: 100%;
   padding: 0.5rem 1rem;
   overflow-wrap: break-word;
 
   font-size: 0.875rem;
-  background-color: ${({ theme, isAi }) =>
-    isAi ? theme.colors.primary : theme.colors.background};
-  color: ${({ theme, isAi }) =>
-    isAi ? theme.colors.textWhite : theme.colors.text};
+  background-color: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
   border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: ${({ theme }) => theme.radius.md};
 `;
@@ -106,4 +104,44 @@ export const ImageCard = styled.img`
   max-height: 200px;
   object-fit: contain;
   border-radius: ${({ theme }) => theme.radius.lg};
+`;
+
+export const AiTextCard = styled.div`
+  width: 100%;
+  padding: 0.5rem 1rem;
+  overflow-wrap: break-word;
+
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  font-size: 0.875rem;
+  background-color: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colors.textWhite};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radius.md};
+
+  > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+
+    font-size: ${({ theme }) => theme.fontSize.caption};
+  }
+
+  > hr {
+    width: 100%;
+    height: 1px;
+    color: ${({ theme }) => theme.colors.textWhite};
+    opacity: 0.5;
+  }
+`;
+
+export const ReplyName = styled.p`
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+`;
+export const ReplyMessage = styled.p`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 `;

--- a/src/components/project/chat/ChatMessageCard/style.ts
+++ b/src/components/project/chat/ChatMessageCard/style.ts
@@ -45,13 +45,12 @@ export const ContainerCard = styled.div`
 export const ImgWrapper = styled.div`
   width: 50px;
   margin-right: 0.5rem;
-  border-radius: ${({ theme }) => theme.radius.full};
   align-self: flex-start;
-  overflow: hidden;
 
   > img {
     width: 100%;
     height: 100%;
+    border-radius: ${({ theme }) => theme.radius.full};
   }
 `;
 
@@ -134,6 +133,10 @@ export const AiTextCard = styled.div`
     height: 1px;
     color: ${({ theme }) => theme.colors.textWhite};
     opacity: 0.5;
+  }
+
+  > p {
+    white-space: pre-wrap;
   }
 `;
 

--- a/src/components/project/chat/ChatMessages/index.tsx
+++ b/src/components/project/chat/ChatMessages/index.tsx
@@ -24,7 +24,7 @@ const ChatMessages = ({ roomId, client }: ChatMessagesProps) => {
     ...(data?.pages
       .slice()
       .reverse()
-      .flatMap((page) => page.messageList) ?? []),
+      .flatMap((page) => page.content) ?? []),
     ...newMessages,
   ];
 

--- a/src/components/project/chat/ChatMessages/style.ts
+++ b/src/components/project/chat/ChatMessages/style.ts
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 
 export const MessagesContainer = styled.div`
   flex: 1;
-  padding: 0 0.75rem;
+  padding: 0.625rem 0.75rem;
 
   display: flex;
   flex-direction: column;

--- a/src/query/chat/useGetChat.ts
+++ b/src/query/chat/useGetChat.ts
@@ -9,9 +9,6 @@ export const useGetChat = (roomId: number, size: number = 20) => {
     queryFn: ({ pageParam = 0 }) =>
       getChatHistory(roomId, pageParam as number, size),
     refetchOnWindowFocus: false,
-    getNextPageParam: (data) => {
-      if (data.lastPage) return undefined;
-      return data.page + 1;
-    },
+    getNextPageParam: (data) => (data.last ? undefined : data.number + 1),
   });
 };

--- a/src/query/chat/usePostImage.ts
+++ b/src/query/chat/usePostImage.ts
@@ -2,6 +2,11 @@ import { sendImageMessage } from "@/apis/chat/chat";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
+type Props = {
+  data: FormData;
+  roomId: number;
+};
+
 export const useSendImage = ({
   onSuccess,
   onError,
@@ -10,7 +15,7 @@ export const useSendImage = ({
   onError?: (error: AxiosError<{ message: string }>) => void;
 }) => {
   return useMutation({
-    mutationFn: (data: FormData) => sendImageMessage(data),
+    mutationFn: ({ data, roomId }: Props) => sendImageMessage(data, roomId),
     onSuccess,
     onError,
   });

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -7,6 +7,8 @@ export type ChatMessageProps = {
   isImage: boolean;
   displayType: "Default" | "SameSender" | "SameTime";
   senderType: "MEMBER" | "AI" | "SYSTEM" | "WITHDRAW";
+  originalSenderName: string;
+  originalMessage: string;
 };
 
 export type ChatSendProps = {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -17,9 +17,9 @@ export type ChatSendProps = {
 };
 
 export type ChatApiResponse = {
-  messageList: ChatMessageProps[];
-  lastPage: boolean;
-  page: number;
+  content: ChatMessageProps[];
+  last: boolean;
+  number: number;
 };
 
 export type AiMessageResponse = {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -5,7 +5,7 @@ export type ChatMessageProps = {
   message: string;
   sentAt: string;
   isImage: boolean;
-  displayType: "Default" | "SameSender" | "SameTime";
+  displayType: "DEFAULT" | "SAME_SENDER" | "SAME_TIME";
   senderType: "MEMBER" | "AI" | "SYSTEM" | "WITHDRAW";
   originalSenderName: string;
   originalMessage: string;


### PR DESCRIPTION
## 📝 PR 설명

### 채팅방 페이지 오류 수정 및 기능 추가
- 페이지 진입 시 기본 페이지 선택 기능 추가
- 채팅방 생성 시 인원 목록 필터링 추가
- AI 메세지 형식을 답장 형식처럼 보이도록 기능 추가
- 입장/ 나가기 브로드캐스팅 받은 사용자의 채팅 목록 재렌더링하는 기능 추가
- 구독 해제 시에도 요청 헤더에 토큰을 추가하여 오류 해결

### 백엔드 변경사항 수정
- 페이지네이션 응답값 수정 및 테스트 확인
- 이미지 api 주소 및 응답값 수정 및 테스트 확인
- 채팅 데이터 displayType 수정 및 테스트 확인
- userId -> memberId 누락된 변경사항 수정

### 스타일 수정

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #170 
