### PR TITLE
[FIX] Client 구독 시 useEffect 조건 수정

### DIFF
--- a/src/components/project/chat/ChatMessages/index.tsx
+++ b/src/components/project/chat/ChatMessages/index.tsx
@@ -69,7 +69,7 @@ const ChatMessages = ({ roomId }: ChatMessagesProps) => {
         Authorization: `${accessToken}`,
       });
     };
-  }, [client, roomId, projectId, accessToken, connSeq]);
+  }, [client?.connected, roomId, connSeq]);
 
   // 데이터 받아온 이후
   useEffect(() => {

--- a/src/components/project/home/Description/index.tsx
+++ b/src/components/project/home/Description/index.tsx
@@ -71,7 +71,7 @@ const Description = () => {
         Authorization: `${accessToken}`,
       });
     };
-  }, [client, projectId, accessToken, connSeq, memberId, updatedByName]);
+  }, [client?.connected, projectId, connSeq]);
 
   const { data } = useProjectInfo(projectId);
 

--- a/src/components/project/schedule/ViewSchedule/index.tsx
+++ b/src/components/project/schedule/ViewSchedule/index.tsx
@@ -45,7 +45,7 @@ const ViewSchedule = ({ scheduleData, projectId }: Type) => {
         Authorization: `${accessToken}`,
       });
     };
-  }, [client, projectId, dispatch, accessToken, connSeq]);
+  }, [client?.connected, projectId, connSeq]);
 
   // 선택 해제한 인원 상태 관리
   const [unselectedMember, setUnselectedMember] = useState<number[]>([]);

--- a/src/pages/project/Home/index.tsx
+++ b/src/pages/project/Home/index.tsx
@@ -104,7 +104,7 @@ const Home = () => {
         Authorization: `${accessToken}`,
       });
     };
-  }, [client, projectId, dispatch, accessToken, connSeq]);
+  }, [client?.connected, projectId, connSeq]);
 
   return (
     <Container>

--- a/src/pages/project/Task/index.tsx
+++ b/src/pages/project/Task/index.tsx
@@ -109,7 +109,7 @@ const Task = () => {
         Authorization: `${accessToken}`,
       });
     };
-  }, [client, projectId, accessToken, connSeq]);
+  }, [client?.connected, projectId, connSeq]);
 
   return (
     <TaskContainer>

--- a/src/pages/project/Team/index.tsx
+++ b/src/pages/project/Team/index.tsx
@@ -136,7 +136,7 @@ const Team = () => {
         Authorization: `${accessToken}`,
       });
     };
-  }, [client, projectId, dispatch, accessToken, connSeq]);
+  }, [client?.connected, projectId, connSeq]);
 
   return (
     <Container>


### PR DESCRIPTION
## 📝 PR 설명

- 구독 시 사용했던 useEffect 렌더링 조건의 범위를 줄여 불필요한 재구독 연결이 되는 오류를 해결
- 꼭 필요한 client.connected, projectId, connSeq 이외의 조건 제거

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #183 
