### PR TITLE
fix: 새 창 상태 유지 및 미디어 세션 종료 문제 해결

### DIFF
--- a/src/components/project/meeting/Header/index.tsx
+++ b/src/components/project/meeting/Header/index.tsx
@@ -1,6 +1,4 @@
-import Button from "@/components/common/Button";
-import { AiOutlineBell } from "react-icons/ai";
-import { Container, Content, Logo, UserInfo, UserSection } from "./style";
+import { Container, Content, Logo } from "./style";
 import logo from "@/assets/logo/logo.png";
 
 const MeetingHeader = () => {
@@ -9,23 +7,8 @@ const MeetingHeader = () => {
       <Content>
         <Logo>
           <img src={logo} alt="logo" />
-          <p>Rumon 화상회의방</p>
+          <p>화상회의방</p>
         </Logo>
-
-        <UserSection>
-          <UserInfo>
-            <Button>yundoll</Button>
-            <Button variant="secondary">mar0722@naver.com</Button>
-            <Button variant="secondary" iconOnly>
-              <AiOutlineBell />
-            </Button>
-          </UserInfo>
-
-          <img
-            src="https://we-up-public.s3.ap-northeast-2.amazonaws.com/smiley3.png"
-            alt="profile-iamge"
-          />
-        </UserSection>
       </Content>
     </Container>
   );

--- a/src/components/project/meeting/Header/style.ts
+++ b/src/components/project/meeting/Header/style.ts
@@ -30,21 +30,3 @@ export const Logo = styled.div`
     height: 20px;
   }
 `;
-
-export const UserSection = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 2.5rem;
-
-  > img {
-    width: 1.75rem;
-    height: 1.75rem;
-    border-radius: ${({ theme }) => theme.radius.full};
-  }
-`;
-
-export const UserInfo = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-`;

--- a/src/hooks/useMediaStream.ts
+++ b/src/hooks/useMediaStream.ts
@@ -2,16 +2,33 @@ import { useEffect, useRef, useState } from "react";
 
 export const useMediaStream = (audioOn = true, videoOn = true) => {
   const [stream, setStream] = useState<MediaStream | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const stopStream = () => {
+    if (streamRef.current) {
+      console.log(
+        "[useMediaStream] stopStream, tracks:",
+        streamRef.current.getTracks()
+      );
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+    setStream(null);
+  };
 
   const getStream = async (audio: boolean, video: boolean) => {
     try {
+      stopStream();
+
       const newStream = await navigator.mediaDevices.getUserMedia({
         audio,
         video,
       });
 
+      streamRef.current = newStream;
       setStream(newStream);
+
       if (videoRef.current) {
         videoRef.current.srcObject = newStream;
       }
@@ -20,14 +37,13 @@ export const useMediaStream = (audioOn = true, videoOn = true) => {
     }
   };
 
-  const stopStream = () => {
-    stream?.getTracks().forEach((track) => track.stop());
-    setStream(null);
-  };
-
   useEffect(() => {
     getStream(audioOn, videoOn);
-    return stopStream;
+
+    return () => {
+      console.log("[useMediaStream] cleanup 호출");
+      stopStream();
+    };
   }, [audioOn, videoOn]);
 
   return { stream, videoRef, stopStream };

--- a/src/pages/project/Meet/index.tsx
+++ b/src/pages/project/Meet/index.tsx
@@ -15,7 +15,7 @@ import {
   VideoPreview,
 } from "./style";
 import Button from "@/components/common/Button";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMediaStream } from "@/hooks/useMediaStream";
 import { useMeetingCount } from "@/query/meeting/useMeetingCount";
 import { useTheme } from "@/contexts/ThemeContext";
@@ -23,6 +23,7 @@ import IconLabel from "@/components/common/IconLabel";
 import { BsHeadphones } from "react-icons/bs";
 import { useSelector } from "react-redux";
 import { RootState } from "@/store/store";
+import { useEnterMeeting } from "@/query/meeting/useEnterMeeting";
 
 const Meet = () => {
   // const navigate = useNavigate();
@@ -46,17 +47,44 @@ const Meet = () => {
     setIsCamOn((prev) => !prev);
   };
 
+  const { mutate, data: token } = useEnterMeeting();
+
+  useEffect(() => {
+    if (project_id) mutate(project_id);
+  }, [project_id]);
+
   const handleJoinMeeting = () => {
-    // navigate(`/meeting/${projectId}`);
-    console.log("열기 전 memberId", memberId);
+    if (!token) return;
+
+    const meetingConfig = {
+      token,
+      memberId,
+      isMicOn,
+      isCamOn,
+      theme,
+      projectId,
+      savedAt: Date.now(),
+    };
+
+    localStorage.setItem(
+      `weup:meeting:${projectId}`,
+      JSON.stringify(meetingConfig)
+    );
+
     window.open(
-      `/meeting/${projectId}?memberId=${memberId}&isMicOn=${isMicOn}&isCamOn=${isCamOn}&theme=${theme}`,
+      `/meeting/${projectId}`,
       "_blank",
       "width=932,height=808,toolbar=no,menubar=no,scrollbars=yes,resizable=yes,noopener,noreferrer"
     );
   };
 
-  const { videoRef, stream } = useMediaStream(isMicOn, isCamOn);
+  const { videoRef, stream, stopStream } = useMediaStream(isMicOn, isCamOn);
+
+  useEffect(() => {
+    return () => {
+      stopStream();
+    };
+  }, []);
 
   return (
     <Container>


### PR DESCRIPTION
## 📝 PR 설명

- window.open 시 React 상태 초기화로 인해 token 및 설정값 유실되는 문제 발생 -> meetingConfig(상태 값)를 localStorage에 저장하여 API 호출 없이 정보 적용

- 화상회의 대기실에 cleanup 함수 추가하여 다른 탭 이동 시 웹캠, 마이크 즉시 종료

- useMediaStream 훅 리팩터링 -> 기존 cleanup 시 stream이 null 상태로 고정되어있어 stop() 미동작 -> MediaStream을 ref 기반으로 관리하도록 수정

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #208 
